### PR TITLE
Create NY and MO Facilities from external data source - Iteration 3

### DIFF
--- a/lib/facility_factory.rb
+++ b/lib/facility_factory.rb
@@ -19,6 +19,14 @@ class FacilityFactory
                     phone: facility[:public_phone_number]
                 }
                 Facility.new(facility_details)
+            else facility[:state] == 'MO'
+                facility_details = {
+                    name: facility[:name],
+                    address: format_address(facility[:address1], facility[:address_2], 
+                    facility[:city], facility[:state], facility[:zipcode]),
+                    phone: facility[:phone]
+                }
+                Facility.new(facility_details)
             end
         end
     end

--- a/lib/facility_factory.rb
+++ b/lib/facility_factory.rb
@@ -5,7 +5,7 @@ class FacilityFactory
             if facility[:state] == 'CO'
                 facility_details = {
                     name: facility[:dmv_office],
-                    address: format_co_address(facility[:address_li], facility[:address__1], 
+                    address: format_address(facility[:address_li], facility[:address__1], 
                     facility[:city], facility[:state], facility[:zip]),
                     phone: facility[:phone]
                 }
@@ -13,8 +13,9 @@ class FacilityFactory
             elsif facility[:state] == 'NY'
                 facility_details = {
                     name: facility[:office_name],
-                    address: format_ny_address(facility[:street_address_line_1], 
-                    facility[:city], facility[:state], facility[:zip_code]),
+                    address: format_address(facility[:street_address_line_1], 
+                    facility[:street_address_line_2], facility[:city], facility[:state], 
+                    facility[:zip_code]),
                     phone: facility[:public_phone_number]
                 }
                 Facility.new(facility_details)
@@ -22,11 +23,7 @@ class FacilityFactory
         end
     end
 
-    def format_co_address(address_1, address_2, city, state, zip)
+    def format_address(address_1, address_2, city, state, zip)
         "#{address_1} #{address_2} #{city} #{state} #{zip}"
-    end
-
-    def format_ny_address(address, city, state, zip)
-        "#{address} #{city} #{state} #{zip}"
     end
 end

--- a/lib/facility_factory.rb
+++ b/lib/facility_factory.rb
@@ -2,17 +2,31 @@ class FacilityFactory
 
     def create_facilities(facility_data)
         facility_data.map do |facility|
-            facility_details = {
-                name: facility[:dmv_office],
-                address: format_co_address(facility[:address_li], facility[:address__1], 
-                facility[:city], facility[:state], facility[:zip]),
-                phone: facility[:phone]
-            }
-            Facility.new(facility_details)
+            if facility[:state] == 'CO'
+                facility_details = {
+                    name: facility[:dmv_office],
+                    address: format_co_address(facility[:address_li], facility[:address__1], 
+                    facility[:city], facility[:state], facility[:zip]),
+                    phone: facility[:phone]
+                }
+                Facility.new(facility_details)
+            elsif facility[:state] == 'NY'
+                facility_details = {
+                    name: facility[:office_name],
+                    address: format_ny_address(facility[:street_address_line_1], 
+                    facility[:city], facility[:state], facility[:zip_code]),
+                    phone: facility[:public_phone_number]
+                }
+                Facility.new(facility_details)
+            end
         end
     end
 
     def format_co_address(address_1, address_2, city, state, zip)
         "#{address_1} #{address_2} #{city} #{state} #{zip}"
+    end
+
+    def format_ny_address(address, city, state, zip)
+        "#{address} #{city} #{state} #{zip}"
     end
 end

--- a/spec/facility_factory_spec.rb
+++ b/spec/facility_factory_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe FacilityFactory do
     end
 
     describe '#create_facilities' do
-        describe 'creating CO facilities' do
+        describe 'creating CO facilities' do #make tests more specific
             it 'can use data to create new CO DMV Facility instances' do
                 facilities = @factory.create_facilities(@co_dmv_office_locations)
                 expect(facilities).to be_an_instance_of(Array)
@@ -52,7 +52,7 @@ RSpec.describe FacilityFactory do
             end
         end
 
-        describe 'creating NY facilities' do
+        describe 'creating NY facilities' do #make tests more specific
             it 'can use data to create new NY DMV Facility instances' do
                 facilities = @factory.create_facilities(@new_york_facilities)
                 expect(facilities).to be_an_instance_of(Array)
@@ -81,17 +81,10 @@ RSpec.describe FacilityFactory do
         end
     end
 
-    describe '#format_co_address' do
-        it 'has proper formatting for CO addresses' do
+    describe '#format_address' do
+        it 'has proper formatting for addresses' do
             expected = 'address_1 address_2 city state zip'
-            expect(@factory.format_co_address('address_1', 'address_2', 'city', 'state', 'zip')).to eq(expected)
-        end
-    end
-
-    describe '#format_ny_address' do
-        it 'has proper formatting for NY addresses' do
-            expected = 'address city state zip'
-            expect(@factory.format_ny_address('address', 'city', 'state', 'zip')).to eq(expected)
+            expect(@factory.format_address('address_1', 'address_2', 'city', 'state', 'zip')).to eq(expected)
         end
     end
 end

--- a/spec/facility_factory_spec.rb
+++ b/spec/facility_factory_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe FacilityFactory do
         @factory = FacilityFactory.new
         @co_dmv_office_locations = DmvDataService.new.co_dmv_office_locations
         @new_york_facilities = DmvDataService.new.ny_dmv_office_locations
+        @missouri_facilities = DmvDataService.new.mo_dmv_office_locations
     end
 
     describe 'loads data' do
@@ -14,6 +15,10 @@ RSpec.describe FacilityFactory do
 
         it 'loads NY DMV data' do
             expect(@new_york_facilities).to be_an_instance_of(Array)
+        end
+
+        it 'loads MO DMV data' do
+            expect(@missouri_facilities).to be_an_instance_of(Array)
         end
     end
 
@@ -75,6 +80,34 @@ RSpec.describe FacilityFactory do
 
             it 'creates proper phone number for the NY DMV Facility instances' do
                 facilities = @factory.create_facilities(@new_york_facilities)
+                expect(facilities.first.phone).not_to eq(nil)
+                expect(facilities.first.phone).to be_a(String)
+            end
+        end
+
+        describe 'creating MO facilities' do #make tests more specific
+            it 'can use data to create new MO DMV Facility instances' do
+                facilities = @factory.create_facilities(@missouri_facilities)
+                expect(facilities).to be_an_instance_of(Array)
+                expect(facilities.size).to be_an(Integer)
+                expect(facilities.first).to be_an_instance_of(Facility)
+                expect(facilities.last).to be_an_instance_of(Facility)
+            end
+
+            it 'creates proper name for the MO DMV Facility instances' do
+                facilities = @factory.create_facilities(@missouri_facilities)
+                expect(facilities.first.name).not_to eq(nil)
+                expect(facilities.first.name).to be_a(String)
+            end
+
+            it 'creates proper address for the MO DMV Facility instances' do
+                facilities = @factory.create_facilities(@missouri_facilities)
+                expect(facilities.first.address).not_to eq(nil)
+                expect(facilities.first.address).to be_a(String)
+            end
+
+            it 'creates proper phone number for the MO DMV Facility instances' do
+                facilities = @factory.create_facilities(@missouri_facilities)
                 expect(facilities.first.phone).not_to eq(nil)
                 expect(facilities.first.phone).to be_a(String)
             end

--- a/spec/facility_factory_spec.rb
+++ b/spec/facility_factory_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe FacilityFactory do
     describe '#format_ny_address' do
         it 'has proper formatting for NY addresses' do
             expected = 'address city state zip'
-            expect(@factory.format_co_address('address', 'city', 'state', 'zip')).to eq(expected)
+            expect(@factory.format_ny_address('address', 'city', 'state', 'zip')).to eq(expected)
         end
     end
 end

--- a/spec/facility_factory_spec.rb
+++ b/spec/facility_factory_spec.rb
@@ -87,4 +87,11 @@ RSpec.describe FacilityFactory do
             expect(@factory.format_co_address('address_1', 'address_2', 'city', 'state', 'zip')).to eq(expected)
         end
     end
+
+    describe '#format_ny_address' do
+        it 'has proper formatting for NY addresses' do
+            expected = 'address city state zip'
+            expect(@factory.format_co_address('address', 'city', 'state', 'zip')).to eq(expected)
+        end
+    end
 end

--- a/spec/facility_factory_spec.rb
+++ b/spec/facility_factory_spec.rb
@@ -4,11 +4,16 @@ RSpec.describe FacilityFactory do
     before(:each) do
         @factory = FacilityFactory.new
         @co_dmv_office_locations = DmvDataService.new.co_dmv_office_locations
+        @new_york_facilities = DmvDataService.new.ny_dmv_office_locations
     end
 
     describe 'loads data' do
         it 'loads CO DMV data' do
             expect(@co_dmv_office_locations).to be_an_instance_of(Array)
+        end
+
+        it 'loads NY DMV data' do
+            expect(@new_york_facilities).to be_an_instance_of(Array)
         end
     end
 
@@ -19,30 +24,60 @@ RSpec.describe FacilityFactory do
     end
 
     describe '#create_facilities' do
-        it 'can use data to create new CO DMV Facility instances' do
-            facilities = @factory.create_facilities(@co_dmv_office_locations)
-            expect(facilities).to be_an_instance_of(Array)
-            expect(facilities.size).to be_an(Integer)
-            expect(facilities.first).to be_an_instance_of(Facility)
-            expect(facilities.last).to be_an_instance_of(Facility)
+        describe 'creating CO facilities' do
+            it 'can use data to create new CO DMV Facility instances' do
+                facilities = @factory.create_facilities(@co_dmv_office_locations)
+                expect(facilities).to be_an_instance_of(Array)
+                expect(facilities.size).to be_an(Integer)
+                expect(facilities.first).to be_an_instance_of(Facility)
+                expect(facilities.last).to be_an_instance_of(Facility)
+            end
+
+            it 'creates proper name for the CO DMV Facility instances' do
+                facilities = @factory.create_facilities(@co_dmv_office_locations)
+                expect(facilities.first.name).not_to eq(nil)
+                expect(facilities.first.name).to be_a(String)
+            end
+
+            it 'creates proper address for the CO DMV Facility instances' do
+                facilities = @factory.create_facilities(@co_dmv_office_locations)
+                expect(facilities.first.address).not_to eq(nil)
+                expect(facilities.first.address).to be_a(String)
+            end
+
+            it 'creates proper phone number for the CO DMV Facility instances' do
+                facilities = @factory.create_facilities(@co_dmv_office_locations)
+                expect(facilities.first.phone).not_to eq(nil)
+                expect(facilities.first.phone).to be_a(String)
+            end
         end
 
-        it 'creates proper name for the CO DMV Facility instances' do
-            facilities = @factory.create_facilities(@co_dmv_office_locations)
-            expect(facilities.first.name).not_to eq(nil)
-            expect(facilities.first.name).to be_a(String)
-        end
+        describe 'creating NY facilities' do
+            it 'can use data to create new NY DMV Facility instances' do
+                facilities = @factory.create_facilities(@new_york_facilities)
+                expect(facilities).to be_an_instance_of(Array)
+                expect(facilities.size).to be_an(Integer)
+                expect(facilities.first).to be_an_instance_of(Facility)
+                expect(facilities.last).to be_an_instance_of(Facility)
+            end
 
-        it 'creates proper address for the CO DMV Facility instances' do
-            facilities = @factory.create_facilities(@co_dmv_office_locations)
-            expect(facilities.first.address).not_to eq(nil)
-            expect(facilities.first.address).to be_a(String)
-        end
+            it 'creates proper name for the NY DMV Facility instances' do
+                facilities = @factory.create_facilities(@new_york_facilities)
+                expect(facilities.first.name).not_to eq(nil)
+                expect(facilities.first.name).to be_a(String)
+            end
 
-        it 'creates proper phone number for the CO DMV Facility instances' do
-            facilities = @factory.create_facilities(@co_dmv_office_locations)
-            expect(facilities.first.phone).not_to eq(nil)
-            expect(facilities.first.phone).to be_a(String)
+            it 'creates proper address for the NY DMV Facility instances' do
+                facilities = @factory.create_facilities(@new_york_facilities)
+                expect(facilities.first.address).not_to eq(nil)
+                expect(facilities.first.address).to be_a(String)
+            end
+
+            it 'creates proper phone number for the NY DMV Facility instances' do
+                facilities = @factory.create_facilities(@new_york_facilities)
+                expect(facilities.first.phone).not_to eq(nil)
+                expect(facilities.first.phone).to be_a(String)
+            end
         end
     end
 


### PR DESCRIPTION
Write tests for #create_facilities - adding functionality to create Facility objects for NY and MO locations.

Add functionality to #create_facilities, in order to create Facility objects for NY and MO locations.

Consolidate format address helpers into one helper method.