### PR TITLE
General Clean Up

### DIFF
--- a/lib/vehicle.rb
+++ b/lib/vehicle.rb
@@ -5,9 +5,9 @@ class Vehicle
               :year,
               :make,
               :model,
-              :engine
-
-  attr_accessor :plate_type, :registration_date
+              :engine,
+              :registration_date,
+              :plate_type
 
   def initialize(vehicle_details)
     @vin = vehicle_details[:vin]

--- a/spec/facility_factory_spec.rb
+++ b/spec/facility_factory_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe FacilityFactory do
     end
 
     describe '#create_facilities' do
-        describe 'creating CO facilities' do #make tests more specific
+        describe 'creating CO facilities' do
             it 'can use data to create new CO DMV Facility instances' do
                 facilities = @factory.create_facilities(@co_dmv_office_locations)
                 expect(facilities).to be_an_instance_of(Array)
@@ -57,7 +57,7 @@ RSpec.describe FacilityFactory do
             end
         end
 
-        describe 'creating NY facilities' do #make tests more specific
+        describe 'creating NY facilities' do
             it 'can use data to create new NY DMV Facility instances' do
                 facilities = @factory.create_facilities(@new_york_facilities)
                 expect(facilities).to be_an_instance_of(Array)
@@ -85,7 +85,7 @@ RSpec.describe FacilityFactory do
             end
         end
 
-        describe 'creating MO facilities' do #make tests more specific
+        describe 'creating MO facilities' do
             it 'can use data to create new MO DMV Facility instances' do
                 facilities = @factory.create_facilities(@missouri_facilities)
                 expect(facilities).to be_an_instance_of(Array)

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe Facility do
 
     it 'can set registration dates of vehicles once registered' do
       @facility_1.add_service('Vehicle Registration')
+      
       expect(@camaro.registration_date).to eq(nil)
       @facility_1.register_vehicle(@camaro)
       expect(@camaro.registration_date).to be_an_instance_of(Date)


### PR DESCRIPTION
Remove attr_accessors from Vehicle class, now that they're not needed.

Add spacing to a test and remove comments from a few tests.